### PR TITLE
P0-S0.3: Complete Sprint 0.3 containerization baseline (Docker + CI build gate)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Version control and metadata
+.git
+.gitignore
+.gitattributes
+
+# Local secrets and environment files
+.env
+.env.*
+!.env.example
+
+# Dependencies and local build output
+node_modules
+.next
+out
+dist
+coverage
+*.tsbuildinfo
+
+# Test artifacts
+test-results
+playwright-report
+
+# Local tooling and IDE files
+.tmp
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Repository content not required for image build context
+docs
+tests
+.github
+.husky

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ DATABASE_URL="postgresql://groundbreak:change_me_local_only@localhost:5432/groun
 
 # Optional local docker-compose overrides
 APP_PORT="3000"
+# For app-only profile, point this to an external/reachable PostgreSQL host (not the compose postgres service).
 APP_DATABASE_URL="postgresql://groundbreak:change_me_local_only@postgres:5432/groundbreak_dev?schema=public"
 POSTGRES_DB="groundbreak_dev"
 POSTGRES_USER="groundbreak"

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ APP_ENV="dev"
 DATABASE_URL="postgresql://groundbreak:change_me_local_only@localhost:5432/groundbreak_dev?schema=public"
 
 # Optional local docker-compose overrides
+APP_PORT="3000"
+APP_DATABASE_URL="postgresql://groundbreak:change_me_local_only@postgres:5432/groundbreak_dev?schema=public"
 POSTGRES_DB="groundbreak_dev"
 POSTGRES_USER="groundbreak"
 POSTGRES_PASSWORD="change_me_local_only"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,17 @@ jobs:
 
       - name: Run E2E smoke tests
         run: npm run test:e2e
+
+  docker-build:
+    name: docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Validate Docker image build
+        run: docker build --no-cache -t project-groundbreak:ci -f Dockerfile .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ These are **not the same thing** and must never be conflated in the architecture
 - Sprint status in repository artifacts:
   - Sprint `0.0` governance baseline: completed
   - Sprint `0.1` tooling baseline: completed (Tasks 1-11)
-  - Sprint `0.2` AWS + database foundation: next execution target
+  - Sprint `0.2` local database foundation (no-spend track): completed (Tasks 1-7)
+  - Sprint `0.3` containerization baseline: next execution target
 - Implemented baseline in code:
   - Next.js App Router scaffold with TypeScript strict mode
   - Tailwind CSS, ESLint, and Prettier configured
@@ -57,12 +58,19 @@ These are **not the same thing** and must never be conflated in the architecture
   - GitHub Actions CI workflow with lint, typecheck, unit tests, build, and E2E smoke jobs
   - npm-only package/lockfile policy documented and enforced
   - Husky local hooks (`pre-commit`, `pre-push`) with `lint-staged` and CI-equivalent local checks
+  - Local PostgreSQL Docker profile with named persistent volume and health check
+  - Prisma setup with initial migration workflow and repeatable DB scripts (`db:generate`, `db:migrate`, `db:check`, `db:studio`)
+  - Runtime environment validation baseline (`APP_ENV`, `DATABASE_URL`) with fail-fast behavior on app/test startup
+  - Prisma-based DB connectivity probe (`npm run db:check`) with actionable diagnostics
+  - DB health check endpoint (`/api/v1/health/db`) with timeout-bounded probe and safe degraded responses
+  - Deferred cloud activation and cost-gate policy documented in `docs/infra/cloud-activation-gate.md`
 - Not implemented yet (by design at this stage):
-  - core backend/API product features
+  - core backend/API product features beyond baseline health/connectivity surfaces
   - ingestion pipeline
   - scoring/fusion pipeline
   - authentication and voting flows
-  - database schema/migrations
+  - MVP domain data model schema (`User`, `Source`, `Article`, `Analysis`, `Vote`, `FactCheckEvidence`, `AuditLog`)
+  - AWS activation execution (`IAM`, `RDS`, and AWS secret-store rollout), deferred behind cost gate
 
 ---
 
@@ -210,7 +218,7 @@ Treat these as the current baseline until explicitly revised.
   - avoid introducing major new features during final stabilization and dissertation-writeup windows; focus on reliability, evaluation evidence, and documentation quality.
 - Sprint output requirement: each sprint must produce implementation, tests, and documentation updates in the same cycle.
 - Progress governance: maintain an actively prioritized backlog with MoSCoW-style scope control (`Must`, `Should`, `Could`, `Won't-now`) to prevent dissertation-risking scope creep.
-- Immediate next execution action: begin Sprint 0.2 (AWS environment strategy, IAM baseline, RDS provisioning path, Prisma workflow, secrets setup, and db connectivity validation) with tests/docs updated in the same cycle.
+- Immediate next execution action: begin Sprint 0.3 (containerization baseline: production-ready `Dockerfile`, compose workflow alignment, image build CI step, and docs updates) with tests/docs updated in the same cycle.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY prisma.config.ts ./prisma.config.ts
 COPY src ./src
 COPY public ./public
 COPY prisma ./prisma
+COPY scripts/validate-runtime-env.mjs ./scripts/validate-runtime-env.mjs
 
 RUN npx prisma generate
 RUN npm run build
@@ -41,18 +42,13 @@ ENV HOSTNAME=0.0.0.0
 
 RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
 
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
-
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
-COPY --from=builder --chown=nextjs:nodejs /app/src/config ./src/config
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@prisma/client ./node_modules/@prisma/client
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/validate-runtime-env.mjs ./scripts/validate-runtime-env.mjs
 
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["sh", "-c", "node scripts/validate-runtime-env.mjs && node server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build-only defaults so next.config runtime env validation succeeds during image build.
+ARG APP_ENV=prod
+ARG DATABASE_URL=postgresql://groundbreak:build_only@localhost:5432/groundbreak_build?schema=public
+ENV APP_ENV=${APP_ENV}
+ENV DATABASE_URL=${DATABASE_URL}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json package-lock.json ./
+COPY next.config.ts tsconfig.json next-env.d.ts ./
+COPY prisma.config.ts ./prisma.config.ts
+COPY src ./src
+COPY public ./public
+COPY prisma ./prisma
+
+RUN npx prisma generate
+RUN npm run build
+RUN rm -rf .next/cache
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
+COPY --from=builder --chown=nextjs:nodejs /app/src/config ./src/config
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@prisma/client ./node_modules/@prisma/client
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ docker compose --profile app up -d app
 docker compose --profile app --profile postgres up -d
 ```
 
+Recommended npm shortcuts for local Docker workflow:
+
+```bash
+npm run docker:up
+npm run docker:logs
+npm run docker:down
+```
+
 Docker image optimization notes (`Sprint 0.3 / Task 4`):
 
 - `.dockerignore` excludes local-only and non-runtime files (`.git`, test outputs, docs, local env files, caches) from build context.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The product goal is to support user judgment with transparent evidence, not decl
 
 ## Current Status
 
-Current phase: `Phase 0 / Sprint 0.2` (Local database foundation, no-spend track).
+Current phase: `Phase 0 / Sprint 0.3` (Containerization baseline).
 
 Implemented so far:
 
@@ -72,7 +72,7 @@ Locked baseline:
 - Git
 - Node.js 20+ (recommended)
 - npm 10+ (recommended)
-- Docker Desktop (for local PostgreSQL)
+- Docker Desktop (for local PostgreSQL and containerized app workflows)
 
 ### Repository setup
 
@@ -108,50 +108,84 @@ Baseline PostgreSQL environment variables used by `docker-compose.yml`:
 - `POSTGRES_PASSWORD` (default: `change_me_local_only`)
 - `POSTGRES_PORT` (default: `5432`)
 
-Start local PostgreSQL:
+### Docker Workflows (Sprint 0.3)
+
+Docker prerequisites for this repository:
+
+- Docker Desktop (or equivalent Docker runtime) installed and running
+- local `.env` created from `.env.example`
+- ports `3000` (app) and `5432` (Postgres) available, or overridden via env
+
+First-run flow (recommended):
 
 ```bash
-docker compose up -d postgres
+copy .env.example .env
+npm run docker:up
+npm run docker:logs
 ```
 
-View PostgreSQL logs:
+Expected local endpoints after startup:
+
+- app: `http://localhost:3000`
+- db health: `http://localhost:3000/api/v1/health/db`
+
+Stop local Docker stack:
 
 ```bash
-docker compose logs -f postgres
+npm run docker:down
 ```
 
-Stop local PostgreSQL:
+Common local Docker flows:
 
-```bash
-docker compose down
-```
-
-Compose profile matrix (`Sprint 0.3` baseline):
-
-- `postgres` profile (`db-only`, dev-only local DB option):
-
-```bash
-docker compose --profile postgres up -d postgres
-```
-
-- `app` profile (`app-only`, requires external DB via `APP_DATABASE_URL` in `.env`):
-
-```bash
-docker compose --profile app up -d app
-```
-
-- `app` + `postgres` profiles (local full-stack baseline):
-
-```bash
-docker compose --profile app --profile postgres up -d
-```
-
-Recommended npm shortcuts for local Docker workflow:
+- build + start app + local Postgres:
 
 ```bash
 npm run docker:up
+```
+
+- stream local logs:
+
+```bash
 npm run docker:logs
+```
+
+- stop and remove stack resources:
+
+```bash
 npm run docker:down
+```
+
+- rebuild app image without stale layers:
+
+```bash
+docker compose --profile app --profile postgres build --no-cache app
+npm run docker:up
+```
+
+Compose profile usage examples:
+
+- `db-only` (dev-only local DB option):
+
+```bash
+docker compose --profile postgres up -d postgres
+docker compose --profile postgres logs -f postgres
+docker compose --profile postgres down
+```
+
+- `app-only` (requires external DB URL via `APP_DATABASE_URL` in `.env`):
+
+```bash
+docker compose --profile app up -d app
+docker compose --profile app logs -f app
+docker compose --profile app down
+```
+
+- `app+db` full local baseline:
+
+```bash
+docker compose --profile app --profile postgres up -d --build
+docker compose --profile app --profile postgres logs -f --tail=200
+docker compose --profile app --profile postgres down
 ```
 
 Docker image optimization notes (`Sprint 0.3 / Task 4`):
@@ -161,6 +195,11 @@ Docker image optimization notes (`Sprint 0.3 / Task 4`):
 - Runtime image does not run `npm ci`; it copies standalone build output instead.
 - Runtime env fail-fast checks are preserved through `scripts/validate-runtime-env.mjs` before server startup.
 - Trade-off: runtime env validation exists in both TypeScript (`src/config/env.ts`) and a lightweight container startup script, which requires keeping validation rules aligned.
+
+Containerization planning references:
+
+- roadmap item: [docs/roadmap.md](docs/roadmap.md) (`Sprint 0.3: Containerization Baseline`)
+- sprint execution doc: [docs/sprints/sprint-0.3.md](docs/sprints/sprint-0.3.md)
 
 ## Secret Hygiene
 
@@ -277,6 +316,34 @@ docker compose logs -f postgres
   - Check local DB status with `npm run db:check`.
   - Check `docker compose ps` and `docker compose logs -f postgres`.
   - Verify `.env` has valid `APP_ENV` and `DATABASE_URL`.
+
+- Docker port conflicts (`3000` app, `5432` postgres):
+  - Check current bindings: `docker ps`.
+  - Override ports in `.env`:
+    - `APP_PORT="3001"`
+    - `POSTGRES_PORT="5433"`
+  - Restart stack: `npm run docker:down` then `npm run docker:up`.
+
+- Stale containers or networks:
+  - Run `npm run docker:down`.
+  - Remove orphan resources: `docker compose --profile app --profile postgres down --remove-orphans`.
+  - Retry startup with `npm run docker:up`.
+
+- Stale Postgres volume state (unexpected old data/schema):
+  - Stop stack: `npm run docker:down`.
+  - Remove local DB volume (destructive for local DB data):
+    - `docker volume rm project-groundbreak_groundbreak_postgres_data`
+  - Start fresh local DB: `npm run docker:up`.
+
+- Build cache confusion (image not reflecting latest changes):
+  - Rebuild without cache:
+    - `docker compose --profile app --profile postgres build --no-cache app`
+  - Restart: `npm run docker:up`.
+
+- Env/config mismatch in container startup:
+  - Validate `.env` contains `APP_ENV` and `DATABASE_URL` with PostgreSQL protocol.
+  - For `app-only` profile, ensure `APP_DATABASE_URL` targets a reachable external DB host.
+  - Inspect startup logs: `docker compose --profile app logs -f app`.
 
 ## Contribution Workflow
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ Stop local PostgreSQL:
 docker compose down
 ```
 
+Compose profile matrix (`Sprint 0.3` baseline):
+
+- `postgres` profile (`db-only`, dev-only local DB option):
+
+```bash
+docker compose --profile postgres up -d postgres
+```
+
+- `app` profile (`app-only`, requires external DB via `APP_DATABASE_URL` in `.env`):
+
+```bash
+docker compose --profile app up -d app
+```
+
+- `app` + `postgres` profiles (local full-stack baseline):
+
+```bash
+docker compose --profile app --profile postgres up -d
+```
+
 ## Secret Hygiene
 
 - Never commit `.env` or any secret-bearing file.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ docker compose --profile app up -d app
 docker compose --profile app --profile postgres up -d
 ```
 
+Docker image optimization notes (`Sprint 0.3 / Task 4`):
+
+- `.dockerignore` excludes local-only and non-runtime files (`.git`, test outputs, docs, local env files, caches) from build context.
+- Next.js uses `output: "standalone"` so runtime image ships only traced production dependencies.
+- Runtime image does not run `npm ci`; it copies standalone build output instead.
+- Runtime env fail-fast checks are preserved through `scripts/validate-runtime-env.mjs` before server startup.
+- Trade-off: runtime env validation exists in both TypeScript (`src/config/env.ts`) and a lightweight container startup script, which requires keeping validation rules aligned.
+
 ## Secret Hygiene
 
 - Never commit `.env` or any secret-bearing file.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Implemented so far:
 - ESLint + Prettier baseline
 - Vitest unit baseline + smoke test
 - Playwright E2E baseline + smoke test
-- GitHub Actions CI checks (lint, typecheck, unit, build, e2e smoke)
+- GitHub Actions CI checks (lint, typecheck, unit, build, e2e smoke, docker build validation)
 
 Not implemented yet (beyond tooling baseline):
 
@@ -200,6 +200,11 @@ Containerization planning references:
 
 - roadmap item: [docs/roadmap.md](docs/roadmap.md) (`Sprint 0.3: Containerization Baseline`)
 - sprint execution doc: [docs/sprints/sprint-0.3.md](docs/sprints/sprint-0.3.md)
+
+CI Docker gate purpose (`Sprint 0.3 / Task 7`):
+
+- CI runs a build-only `docker build` validation job on `push` and `pull_request`.
+- This catches Dockerfile/runtime packaging regressions early without pushing images to any registry.
 
 ## Secret Hygiene
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ name: project-groundbreak
 
 services:
   app:
+    profiles: ["app"]
     build:
       context: .
       dockerfile: Dockerfile
@@ -17,6 +18,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1"]
       interval: 20s
@@ -25,6 +27,8 @@ services:
       start_period: 20s
 
   postgres:
+    # Dev-only local database option. Do not use this container service for production.
+    profiles: ["postgres"]
     image: postgres:16-alpine
     container_name: groundbreak-postgres
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,29 @@
 name: project-groundbreak
 
 services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: project-groundbreak:local
+    container_name: groundbreak-app
+    restart: unless-stopped
+    environment:
+      APP_ENV: ${APP_ENV:-dev}
+      DATABASE_URL: ${APP_DATABASE_URL:-postgresql://groundbreak:change_me_local_only@postgres:5432/groundbreak_dev?schema=public}
+      PORT: "3000"
+    ports:
+      - "${APP_PORT:-3000}:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1"]
+      interval: 20s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   postgres:
     image: postgres:16-alpine
     container_name: groundbreak-postgres

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,9 +94,9 @@ Cloud activation gate policy: `docs/infra/cloud-activation-gate.md`
 
 - [x] Create production-ready `Dockerfile` for Next.js app (multi-stage build)
 - [x] Create `docker-compose.yml` for local development
-- [ ] Add local services profile for:
-  - [ ] app
-  - [ ] postgres (dev-only local DB option)
+- [x] Add local services profile for:
+  - [x] app
+  - [x] postgres (dev-only local DB option)
 - [ ] Add `.dockerignore` and image-size optimization pass
 - [ ] Add local run scripts (`docker compose up/down/logs`)
 - [ ] Document Docker workflows and troubleshooting notes in README

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,8 +92,8 @@ Cloud activation gate policy: `docs/infra/cloud-activation-gate.md`
 
 ### Sprint 0.3: Containerization Baseline (Docker)
 
-- [ ] Create production-ready `Dockerfile` for Next.js app (multi-stage build)
-- [ ] Create `docker-compose.yml` for local development
+- [x] Create production-ready `Dockerfile` for Next.js app (multi-stage build)
+- [x] Create `docker-compose.yml` for local development
 - [ ] Add local services profile for:
   - [ ] app
   - [ ] postgres (dev-only local DB option)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,8 +97,8 @@ Cloud activation gate policy: `docs/infra/cloud-activation-gate.md`
 - [x] Add local services profile for:
   - [x] app
   - [x] postgres (dev-only local DB option)
-- [ ] Add `.dockerignore` and image-size optimization pass
-- [ ] Add local run scripts (`docker compose up/down/logs`)
+- [x] Add `.dockerignore` and image-size optimization pass
+- [x] Add local run scripts (`docker compose up/down/logs`)
 - [ ] Document Docker workflows and troubleshooting notes in README
 - [ ] Add image build step in CI
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,8 +99,8 @@ Cloud activation gate policy: `docs/infra/cloud-activation-gate.md`
   - [x] postgres (dev-only local DB option)
 - [x] Add `.dockerignore` and image-size optimization pass
 - [x] Add local run scripts (`docker compose up/down/logs`)
-- [ ] Document Docker workflows and troubleshooting notes in README
-- [ ] Add image build step in CI
+- [x] Document Docker workflows and troubleshooting notes in README
+- [x] Add image build step in CI
 
 ---
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -104,7 +104,7 @@ Done when:
 
 Checklist:
 
-- [ ] Add `.dockerignore` and image-size optimization pass
+- [x] Add `.dockerignore` and image-size optimization pass
 
 Step-by-step:
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -177,7 +177,7 @@ Done when:
 
 Checklist:
 
-- [ ] Add image build step in CI
+- [x] Add image build step in CI
 
 Step-by-step:
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -126,7 +126,7 @@ Done when:
 
 Checklist:
 
-- [ ] Add local run scripts (`docker compose up/down/logs`)
+- [x] Add local run scripts (`docker compose up/down/logs`)
 
 Step-by-step:
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -151,7 +151,7 @@ Done when:
 
 Checklist:
 
-- [ ] Document Docker workflows and troubleshooting notes in README
+- [x] Document Docker workflows and troubleshooting notes in README
 
 Step-by-step:
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -80,9 +80,9 @@ Done when:
 
 Checklist:
 
-- [ ] Add local services profile for:
-  - [ ] app
-  - [ ] postgres (dev-only local DB option)
+- [x] Add local services profile for:
+  - [x] app
+  - [x] postgres (dev-only local DB option)
 
 Step-by-step:
 

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -1,0 +1,217 @@
+# Sprint 0.3 - Containerization Baseline (Docker)
+
+Status: Planned  
+Owner: Solo developer  
+Goal: Establish a production-ready container baseline for the Next.js app, aligned local Docker workflows, and CI image-build validation.
+
+## Scope
+
+This sprint covers:
+
+- production-ready multi-stage `Dockerfile` for the Next.js app
+- local `docker-compose.yml` baseline for development workflows
+- local service profiles for app and local Postgres
+- `.dockerignore` and image-size optimization pass
+- local helper scripts for `docker compose up/down/logs`
+- README Docker workflow + troubleshooting documentation
+- CI image build step
+
+This sprint does not cover cloud deployment runtime hardening (that remains in later AWS activation and hardening sprints).
+
+---
+
+## Prerequisites
+
+- Sprint 0.2 merged into `dev`
+- Node.js 20+ and npm 10+
+- Docker Desktop (or equivalent Docker runtime) installed
+- existing local `.env` strategy from Sprint 0.2 in place
+
+---
+
+## Task 1 - Create Production-Ready `Dockerfile` (Multi-Stage Build)
+
+Checklist:
+
+- [x] Create production-ready `Dockerfile` for Next.js app (multi-stage build)
+
+Step-by-step:
+
+1. Add a multi-stage `Dockerfile` at repository root:
+   - dependency/install stage
+   - build stage (`npm run build`)
+   - runtime stage with minimal footprint
+2. Configure Next.js for container-friendly runtime output (for example standalone output if selected for this project baseline).
+3. Ensure runtime image runs as non-root user where practical.
+4. Ensure runtime stage only includes required production artifacts.
+5. Validate container boot with environment validation behavior preserved.
+
+Done when:
+
+- `docker build` succeeds consistently from clean checkout
+- container starts and serves the app successfully
+- runtime image excludes avoidable build-time dependencies
+
+---
+
+## Task 2 - Create `docker-compose.yml` for Local Development
+
+Checklist:
+
+- [ ] Create `docker-compose.yml` for local development
+
+Step-by-step:
+
+1. Define local compose services for app runtime and optional local Postgres.
+2. Wire app service environment values for local development behavior.
+3. Define service dependencies and health-check-aware startup ordering where needed.
+4. Ensure port mapping is explicit and conflict-aware.
+5. Keep compose file readable and aligned with no-spend local-first workflows.
+
+Done when:
+
+- `docker compose config` validates without errors
+- local app can run through compose with predictable behavior
+- compose defaults are documented and reproducible
+
+---
+
+## Task 3 - Add Local Services Profile for `app` and `postgres` (Dev-Only DB Option)
+
+Checklist:
+
+- [ ] Add local services profile for:
+  - [ ] app
+  - [ ] postgres (dev-only local DB option)
+
+Step-by-step:
+
+1. Add/adjust compose profiles so the app and local database can be run together or independently.
+2. Keep Postgres profile explicitly dev-only and avoid accidental production coupling.
+3. Ensure profile commands are straightforward (for example app-only, db-only, app+db).
+4. Verify profile behavior with actual compose runs.
+5. Capture profile matrix in docs.
+
+Done when:
+
+- app and Postgres can be started independently via profiles
+- app + Postgres combined profile path works for local development
+- profile intent (dev-only local DB) is explicit in documentation
+
+---
+
+## Task 4 - Add `.dockerignore` and Perform Image-Size Optimization Pass
+
+Checklist:
+
+- [ ] Add `.dockerignore` and image-size optimization pass
+
+Step-by-step:
+
+1. Create/update `.dockerignore` to exclude unnecessary build context (for example `.git`, test artifacts, local caches, docs not needed for runtime).
+2. Ensure local secrets and environment files are excluded from build context where appropriate.
+3. Optimize Docker layer ordering for cache reuse.
+4. Rebuild image and compare build context/image size before/after.
+5. Document optimization choices and any trade-offs.
+
+Done when:
+
+- build context excludes unnecessary files
+- image size is reduced versus naive baseline
+- no required runtime files are accidentally excluded
+
+---
+
+## Task 5 - Add Local Run Scripts (`docker compose up/down/logs`)
+
+Checklist:
+
+- [ ] Add local run scripts (`docker compose up/down/logs`)
+
+Step-by-step:
+
+1. Add npm scripts for common local Docker workflows:
+   - `docker:up`
+   - `docker:down`
+   - `docker:logs`
+2. Optionally add profile-specific convenience scripts if they reduce operational friction.
+3. Ensure script names are consistent with existing script conventions.
+4. Validate scripts on a clean local setup.
+5. Reference scripts in README workflow section.
+
+Done when:
+
+- local Docker workflows are runnable via npm scripts
+- scripts map to deterministic compose behavior
+- developer onboarding is simpler than raw manual commands
+
+---
+
+## Task 6 - Document Docker Workflows and Troubleshooting in README
+
+Checklist:
+
+- [ ] Document Docker workflows and troubleshooting notes in README
+
+Step-by-step:
+
+1. Add Docker setup prerequisites and first-run flow.
+2. Document common local flows (build, start, stop, logs, rebuild).
+3. Add profile usage examples (app-only, db-only, app+db).
+4. Add troubleshooting notes for frequent issues:
+   - port conflicts
+   - stale containers/volumes
+   - build cache confusion
+   - env/config mismatch
+5. Cross-link sprint and roadmap artifacts where relevant.
+
+Done when:
+
+- README enables a new collaborator to run Docker workflows without guesswork
+- troubleshooting guidance covers the most likely local blockers
+- Docker workflow docs remain consistent with actual scripts and compose files
+
+---
+
+## Task 7 - Add Image Build Step in CI
+
+Checklist:
+
+- [ ] Add image build step in CI
+
+Step-by-step:
+
+1. Update CI workflow to include Docker image build validation.
+2. Ensure build step fails PRs when `Dockerfile` is broken.
+3. Keep CI cost/runtime reasonable (build-only validation at this stage, no registry push required).
+4. Capture build logs/artifacts only if needed for debugging.
+5. Document CI Docker check purpose in repository docs.
+
+Done when:
+
+- CI runs Docker image build successfully on valid changes
+- Docker regressions surface early in pull requests
+- workflow remains stable and maintainable for solo development
+
+---
+
+## Suggested Execution Order
+
+1. Task 1
+2. Task 4
+3. Task 2
+4. Task 3
+5. Task 5
+6. Task 6
+7. Task 7
+
+---
+
+## Sprint 0.3 Exit Criteria
+
+- Multi-stage production-ready `Dockerfile` exists and builds successfully.
+- Local compose workflow supports app and optional local Postgres via profiles.
+- `.dockerignore` is present and image-size optimization has been applied.
+- Common Docker operations are available via npm scripts.
+- README includes accurate Docker runbook and troubleshooting notes.
+- CI validates Docker image build on pull requests.

--- a/docs/sprints/sprint-0.3.md
+++ b/docs/sprints/sprint-0.3.md
@@ -58,7 +58,7 @@ Done when:
 
 Checklist:
 
-- [ ] Create `docker-compose.yml` for local development
+- [x] Create `docker-compose.yml` for local development
 
 Step-by-step:
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import "./src/config/runtime-env";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["localhost", "127.0.0.1"],
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
     "db:check": "node scripts/db-check.mjs",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "docker:up": "docker compose --profile app --profile postgres up -d --build",
+    "docker:down": "docker compose --profile app --profile postgres down",
+    "docker:logs": "docker compose --profile app --profile postgres logs -f --tail=200"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/scripts/validate-runtime-env.mjs
+++ b/scripts/validate-runtime-env.mjs
@@ -1,0 +1,32 @@
+const allowedAppEnv = new Set(["dev", "test", "prod"]);
+
+const appEnv = process.env.APP_ENV;
+const databaseUrl = process.env.DATABASE_URL;
+const errors = [];
+
+if (!allowedAppEnv.has(appEnv ?? "")) {
+  errors.push("APP_ENV: APP_ENV must be one of: dev, test, prod.");
+}
+
+if (!databaseUrl) {
+  errors.push("DATABASE_URL: DATABASE_URL is required.");
+} else {
+  try {
+    const parsed = new URL(databaseUrl);
+
+    if (parsed.protocol !== "postgresql:" && parsed.protocol !== "postgres:") {
+      errors.push("DATABASE_URL: DATABASE_URL must start with postgresql:// or postgres://.");
+    }
+  } catch {
+    errors.push("DATABASE_URL: DATABASE_URL must be a valid URL.");
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Invalid runtime environment configuration.");
+  for (const error of errors) {
+    console.error(error);
+  }
+  console.error("Update your .env using .env.example as a baseline.");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements Sprint 0.3 containerization baseline end-to-end:
- production-ready multi-stage Dockerfile for Next.js
- local docker-compose app/postgres workflow with profiles
- `.dockerignore` + image-size optimization
- npm Docker run scripts (`docker:up`, `docker:down`, `docker:logs`)
- README Docker runbook + troubleshooting updates
- CI Docker image build validation job (build-only, no push)

## Scope
- [ ] Backend
- [ ] Frontend
- [ ] ML/Pipeline
- [x] Infra/DevOps
- [ ] Docs only

## Testing
- [ ] Unit
- [x] Integration
- [ ] E2E
- [ ] Not applicable (reason)

Integration evidence:
- `docker build --no-cache -t project-groundbreak:ci-local-check -f Dockerfile .` passes
- `npm run docker:up` / `npm run docker:down` pass
- compose profile modes verified (`app-only`, `db-only`, `app+db`)
- `http://localhost:3000/api/v1/health/db` returns `200` in compose stack
- `npm run lint` and `npm run typecheck` pass

## Documentation
- [x] Updated relevant docs
- [ ] Not applicable (reason)

Updated docs:
- `README.md` (Docker workflows, first-run, troubleshooting, CI Docker gate purpose)
- `docs/sprints/sprint-0.3.md` (tasks 1-7 status updates)

## Security Impact
- [ ] None
- [x] Yes (describe)

Security-relevant changes:
- `.dockerignore` now excludes `.env` and other local artifacts from Docker build context
- runtime env validation remains fail-fast in container startup path

## Risks / Rollback

Primary risk:
- runtime start path switched to standalone output + startup env validation script

Rollback:
1. Revert Docker/Next containerization changes (`Dockerfile`, `next.config.ts`, `scripts/validate-runtime-env.mjs`, `.dockerignore`)
2. Revert compose/profile/script/doc updates
3. Remove CI `docker build` job from workflow
